### PR TITLE
Change start_time to include milliseconds as decimal

### DIFF
--- a/src/main/java/com/blazemeter/taurus/reporting/Sample.java
+++ b/src/main/java/com/blazemeter/taurus/reporting/Sample.java
@@ -1,5 +1,7 @@
 package com.blazemeter.taurus.reporting;
 
+import java.math.BigDecimal;
+
 public class Sample {
     public static final String STATUS_PASSED = "PASSED";
     public static final String STATUS_FAILED = "FAILED";
@@ -13,8 +15,8 @@ public class Sample {
     private String suite = "";
     private String file = "";
     private String fullName = "";
-    private String errorMessage = "";
-    private String errorTrace = "";
+    private String errorMessage;
+    private String errorTrace;
     private String description = "";
 
     private int activeThreads;
@@ -36,8 +38,9 @@ public class Sample {
         this.startTime = startTime;
     }
 
-    public long getStartTimeInSec() {
-        return startTime / 1000;
+    //using BigDecimal to avoid losing information due to double and float precision issues
+    public BigDecimal getStartTimeInSec() {
+        return BigDecimal.valueOf(startTime, 3);
     }
 
     public long getStartTime() {
@@ -77,7 +80,7 @@ public class Sample {
     }
 
     public void setErrorMessage(String message) {
-        this.errorMessage = message == null ? "" : message;
+        this.errorMessage = message;
     }
 
     public String getErrorTrace() {
@@ -85,7 +88,7 @@ public class Sample {
     }
 
     public void setErrorTrace(String trace) {
-        this.errorTrace = trace == null ? "" : trace;
+        this.errorTrace = trace;
     }
 
     public String getFile() {

--- a/src/main/java/com/blazemeter/taurus/reporting/TaurusReporter.java
+++ b/src/main/java/com/blazemeter/taurus/reporting/TaurusReporter.java
@@ -114,8 +114,9 @@ public class TaurusReporter implements Reporter {
             obj.put("start_time", sample.getStartTimeInSec());
             obj.put("duration", sample.getDurationInSec());
             obj.put("status", sample.getStatus());
-            obj.put("error_msg", sample.getErrorMessage());
-            obj.put("error_trace", sample.getErrorTrace());
+            // using JSONObject.wrap to keep null values in resulting JSON
+            obj.put("error_msg", JSONObject.wrap(sample.getErrorMessage()));
+            obj.put("error_trace", JSONObject.wrap(sample.getErrorTrace()));
             JSONObject extras = new JSONObject();
             extras.put("full_name", sample.getFullName());
             obj.put("extras", extras);
@@ -139,11 +140,12 @@ public class TaurusReporter implements Reporter {
             builder.append(sample.getLabel()).append(','); // label
 
             builder.append(','); // responseCode
-            builder.append(sample.getErrorMessage()).append(','); // responseMessage
+            String errorMsg = sample.getErrorMessage() == null ? "" : sample.getErrorMessage();
+            builder.append(errorMsg).append(','); // responseMessage
 
             builder.append(sample.isSuccessful()).append(','); // success
             builder.append(sample.getActiveThreads()).append(","); // allThreads
-            builder.append(sample.getErrorMessage().getBytes().length).append("\r\n");
+            builder.append(errorMsg.getBytes().length).append("\r\n");
             return builder.toString();
         }
     }

--- a/src/test/java/com/blazemeter/taurus/reporting/SampleTest.java
+++ b/src/test/java/com/blazemeter/taurus/reporting/SampleTest.java
@@ -4,6 +4,8 @@ import categories.TestCategory;
 import junit.framework.TestCase;
 import org.junit.experimental.categories.Category;
 
+import java.math.BigDecimal;
+
 @Category(TestCategory.class)
 public class SampleTest extends TestCase {
 
@@ -16,7 +18,7 @@ public class SampleTest extends TestCase {
         assertTrue(t1 <= sample.getStartTime());
 
         long start = sample.getStartTime();
-        assertEquals(start / 1000, sample.getStartTimeInSec());
+        assertEquals(BigDecimal.valueOf(start, 3), sample.getStartTimeInSec());
 
         assertTrue(sample.isSuccessful());
         assertFalse(sample.isSkipped());
@@ -53,12 +55,12 @@ public class SampleTest extends TestCase {
         assertEquals("file", sample.getFile());
 
         sample.setErrorMessage(null);
-        assertEquals("", sample.getErrorMessage());
+        assertNull(sample.getErrorMessage());
         sample.setErrorMessage("msg");
         assertEquals("msg", sample.getErrorMessage());
 
         sample.setErrorTrace(null);
-        assertEquals("", sample.getErrorTrace());
+        assertNull(sample.getErrorTrace());
         sample.setErrorTrace("trace");
         assertEquals("trace", sample.getErrorTrace());
 

--- a/src/test/java/com/blazemeter/taurus/reporting/TaurusReporterTest.java
+++ b/src/test/java/com/blazemeter/taurus/reporting/TaurusReporterTest.java
@@ -7,6 +7,7 @@ import org.junit.experimental.categories.Category;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.math.BigDecimal;
 
 import static org.apache.commons.io.FileUtils.readFileToString;
 
@@ -69,8 +70,8 @@ public class TaurusReporterTest extends TestCase {
         reporter.close();
 
         StringBuilder expect = new StringBuilder("{\"duration\":5,\"start_time\":");
-        expect.append(startTime / 1000);
-        expect.append(",\"test_suite\":\"\",\"error_msg\":\"Oppps!\",\"extras\":{\"full_name\":\"\"},\"error_trace\":\"\",\"test_case\":\"TestLabel\",\"status\":\"FAILED\"}\n");
+        expect.append(BigDecimal.valueOf(startTime,3));
+        expect.append(",\"test_suite\":\"\",\"error_msg\":\"Oppps!\",\"extras\":{\"full_name\":\"\"},\"error_trace\":null,\"test_case\":\"TestLabel\",\"status\":\"FAILED\"}\n");
 
         String actual = readFileToString(file);
         assertEquals(expect.toString(), actual);


### PR DESCRIPTION
To avoid losing information (the milliseconds part) when generating start_time value in ldjson report, and to be more consistent with other runners (mocha, pyrest, etc), we include milliseconds as decimal as is done in other runners (mocha uses milliseconds as decimal, nose, pytest and rspec report microseconds).
Additionally, to be consistent with other runners (mocha, pyrest, etc), change generated ldjson error_trace and error_msg values from empty string to null when no error is reported.