### PR TITLE
Add JUnit5 DisplayName support

### DIFF
--- a/src/test/java/com/blazemeter/taurus/junit/runner/junit5/JUnit5ListenerTest.java
+++ b/src/test/java/com/blazemeter/taurus/junit/runner/junit5/JUnit5ListenerTest.java
@@ -13,6 +13,7 @@ import org.junit.platform.engine.TestExecutionResult;
 import org.junit.platform.engine.UniqueId;
 import org.junit.platform.launcher.TestIdentifier;
 import testcases.subpackage.TestCase5;
+import testcases.subpackage.TestCase6;
 
 import java.io.File;
 import java.io.IOException;
@@ -71,5 +72,43 @@ public class JUnit5ListenerTest extends TestCase {
 
         status = listener.getStatusFromThrowableType(new RuntimeException(""));
         assertEquals(Sample.STATUS_BROKEN, status);
+    }
+
+    public void testDefaultName() throws Exception {
+        File tmp = new File("tmp.ldjson");
+        tmp.deleteOnExit();
+
+        TaurusReporter reporter = new TaurusReporter(tmp.getAbsolutePath());
+        JUnit5Listener listener = new JUnit5Listener(reporter, new Counter());
+
+        Method method = TestCase5.class.getDeclaredMethod("testJUnit5Method");
+        TestIdentifier identifier = TestIdentifier.from(new TestMethodTestDescriptor(UniqueId.forEngine("123"), TestCase5.class, method));
+        listener.startSample(identifier);
+        listener.executionFinished(identifier, TestExecutionResult.successful());
+
+        reporter.close();
+
+        String s = CustomRunnerTest.readFileToString(tmp);
+        assertTrue(s, s.contains("\"full_name\":\"testcases.subpackage.TestCase5.testJUnit5Method\""));
+        assertTrue(s, s.contains("\"test_case\":\"testJUnit5Method\""));
+    }
+
+    public void testDisplayName() throws Exception {
+        File tmp = new File("tmp.ldjson");
+        tmp.deleteOnExit();
+
+        TaurusReporter reporter = new TaurusReporter(tmp.getAbsolutePath());
+        JUnit5Listener listener = new JUnit5Listener(reporter, new Counter());
+
+        Method method = TestCase6.class.getDeclaredMethod("methodName");
+        TestIdentifier identifier = TestIdentifier.from(new TestMethodTestDescriptor(UniqueId.forEngine("123"), TestCase6.class, method));
+        listener.startSample(identifier);
+        listener.executionFinished(identifier, TestExecutionResult.successful());
+
+        reporter.close();
+
+        String s = CustomRunnerTest.readFileToString(tmp);
+        assertTrue(s, s.contains("\"full_name\":\"testcases.subpackage.TestCase6.DisplayNameValue\""));
+        assertTrue(s, s.contains("\"test_case\":\"DisplayNameValue\""));
     }
 }

--- a/src/test/java/testcases/subpackage/TestCase6.java
+++ b/src/test/java/testcases/subpackage/TestCase6.java
@@ -1,0 +1,17 @@
+package testcases.subpackage;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+public class TestCase6 {
+    @Test
+    @DisplayName("DisplayNameValue")
+    void methodName() {
+        Assertions.assertEquals("1", "1");
+    }
+}


### PR DESCRIPTION
Add support for JUnit's DisplayName annotation.

This would be an incredibly shorter PR if `MethodSource` had `getJavaMethod()` available, however that wasn't added until JUnit 5.7.0 (see https://junit.org/junit5/docs/5.7.0-RC1/release-notes/#new-features-and-improvements).

![Screenshot 2024-04-30 at 3 25 33 PM](https://github.com/Blazemeter/taurus-java-helpers/assets/12680312/8ba92f93-f29d-4cce-9a58-ca07f6e4a92b)

Instead of bumping the library which could have consequences I'm unfamiliar with, I simply implemented a simple version of the `getJavaMethod` from JUnit source code (see https://github.com/junit-team/junit5/commit/a91115b6edc94bb02a1f0863d4c11ddb8536777f#diff-a3b9d7b15fda5731d678ec8a73b0bb42b6cb2c203dab1f6520c26771027ca8e2R208)
